### PR TITLE
Download files to their original relative paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,13 @@ lazy val commonSettings = Seq(
 lazy val download = (project in file("download"))
   .settings(commonSettings: _*)
   .settings(
-    assemblyJarName in assembly := "tdr-download.jar"
+    assemblyJarName in assembly := "tdr-download.jar",
+    libraryDependencies ++= Seq(
+      "ca.ryangreen" % "apigateway-generic-java-sdk" % "1.3",
+      "io.circe" %% "circe-core" % "0.12.1",
+      "io.circe" %% "circe-generic" % "0.12.1",
+      "io.circe" %% "circe-parser" % "0.12.1"
+    )
   )
 
 lazy val exportZip = (project in file("export-zip"))

--- a/download/src/main/scala/DownloadFiles.scala
+++ b/download/src/main/scala/DownloadFiles.scala
@@ -1,59 +1,15 @@
-import java.io.File
-import java.nio.file.{Files, Path, Paths}
-import java.util.function.Consumer
+import uk.gov.nationalarchives.tdr.export.api.ApiQueries
+import uk.gov.nationalarchives.tdr.export.s3.S3Download
 
-import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, ListObjectsV2Request, S3Object}
-import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable
+import scala.util.{Failure, Success}
 
 object DownloadFiles extends App {
 
-  val client = S3Client.create
+  val consignmentId = sys.env("CONSIGNMENT_ID").toInt
+  val fileDetails = ApiQueries.getFiles(consignmentId)
 
-  val bucketName = sys.env.getOrElse("INPUT_BUCKET_NAME", "tdr-files")
-  val folderName = sys.env.getOrElse("INPUT_FOLDER_NAME", "tmp-play-app")
-
-  val consumer: Consumer[ListObjectsV2Request.Builder] = (requestBuilder: ListObjectsV2Request.Builder) => {
-    requestBuilder
-      .bucket(bucketName)
-      .prefix(folderName)
-  }
-  val response: ListObjectsV2Iterable = client.listObjectsV2Paginator(consumer)
-
-  val tempFolderName = sys.env.get("OUTPUT_DIR")
-  val tempFolder = tempFolderName match {
-    case Some(folderName) => Paths.get(folderName)
-    case None => Files.createTempDirectory("tdr-export")
-  }
-
-  println(s"Saving files to ${tempFolder.toAbsolutePath}")
-
-  println("S3 objects:")
-  response.contents.stream.forEach(s3Object => {
-    if (s3Object.key.endsWith("/")) {
-      println(s"Skipping '${s3Object.key}' because it is a directory")
-    } else if (s3Object.size == 0) {
-      println(s"Skipping '${s3Object.key}' because size is zero")
-    } else {
-      println(s"Downloading '${s3Object.key}'")
-      download(s3Object, tempFolder.toAbsolutePath)
-    }
-  })
-
-  private def download(s3Object: S3Object, tempFolder: Path): Unit = {
-    val parentPath = Paths.get(s3Object.key).getParent
-    if (parentPath != null) createDirectory(parentPath.toString, tempFolder)
-
-    val objectRequest = GetObjectRequest.builder
-      .bucket(bucketName)
-      .key(s3Object.key)
-      .build
-    val outputPath: Path = Paths.get(s"$tempFolder/${s3Object.key}")
-    client.getObject(objectRequest, outputPath)
-  }
-
-  private def createDirectory(directoryPath: String, tempFolder: Path): Unit = {
-    val absolutePath = Paths.get(s"${tempFolder.toAbsolutePath}/$directoryPath")
-    new File(absolutePath.toString).mkdirs
+  fileDetails match {
+    case Success(files) => S3Download.downloadFiles(files, consignmentId)
+    case Failure(e) => throw e
   }
 }

--- a/download/src/main/scala/uk/gov/nationalarchives/tdr/export/api/ApiClient.scala
+++ b/download/src/main/scala/uk/gov/nationalarchives/tdr/export/api/ApiClient.scala
@@ -1,0 +1,45 @@
+package uk.gov.nationalarchives.tdr.export.api
+
+import java.io.ByteArrayInputStream
+
+import ca.ryangreen.apigateway.generic.{GenericApiGatewayClientBuilder, GenericApiGatewayRequestBuilder, GenericApiGatewayResponse}
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.http.HttpMethodName
+import com.amazonaws.regions.{Region, Regions}
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+import scala.jdk.CollectionConverters._
+
+class ApiClient {
+
+  def sendQueryToApi(queryString: String): String = {
+    case class Query(query: String)
+
+    val query = Query(queryString)
+
+    val apiGatewayClient = new GenericApiGatewayClientBuilder()
+      .withClientConfiguration(new ClientConfiguration)
+      .withCredentials(new DefaultAWSCredentialsProviderChain)
+      .withEndpoint(sys.env("GRAPHQL_SERVER"))
+      .withRegion(Region.getRegion(Regions.EU_WEST_2))
+      .build
+
+    val headers = Map("Content-Type" -> "application/json").asJava
+
+    val requestBody = query.asJson.toString()
+    val request = new GenericApiGatewayRequestBuilder()
+      .withBody(new ByteArrayInputStream(requestBody.getBytes))
+      .withHttpMethod(HttpMethodName.POST)
+      .withHeaders(headers)
+      .withResourcePath(sys.env("GRAPHQL_PATH"))
+      .build
+
+    val response: GenericApiGatewayResponse = apiGatewayClient.execute(request)
+
+    println("Response:")
+    println(response.getHttpResponse.getStatusCode)
+    response.getBody
+  }
+}

--- a/download/src/main/scala/uk/gov/nationalarchives/tdr/export/api/ApiQueries.scala
+++ b/download/src/main/scala/uk/gov/nationalarchives/tdr/export/api/ApiQueries.scala
@@ -1,0 +1,28 @@
+package uk.gov.nationalarchives.tdr.export.api
+
+import io.circe
+import io.circe.generic.auto._
+import io.circe.parser.decode
+
+import scala.util.{Failure, Success, Try}
+
+object ApiQueries {
+  def getFiles(consignmentId: Int): Try[Seq[File]] = {
+    val apiClient = new ApiClient
+
+    val graphqlQuery = s"""query { getConsignment(id: $consignmentId) { files { id, path } } }"""
+
+    val responseBody = apiClient.sendQueryToApi(graphqlQuery)
+    val apiResponse: Either[circe.Error, GetConsignmentResponse] = decode[GetConsignmentResponse](responseBody)
+
+    apiResponse match {
+      case Right(consignmentResponse) => Success(consignmentResponse.data.getConsignment.files)
+      case Left(e) => Failure(e)
+    }
+  }
+}
+
+case class GetConsignmentResponse(data: GetConsignmentResponseData)
+case class GetConsignmentResponseData(getConsignment: ConsignmentData)
+case class ConsignmentData(files: Seq[File])
+case class File(id: String, path: String)

--- a/download/src/main/scala/uk/gov/nationalarchives/tdr/export/s3/S3Download.scala
+++ b/download/src/main/scala/uk/gov/nationalarchives/tdr/export/s3/S3Download.scala
@@ -1,0 +1,47 @@
+package uk.gov.nationalarchives.tdr.export.s3
+
+import java.nio.file.{Files, Path, Paths}
+
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import uk.gov.nationalarchives.tdr.export.api.File
+
+object S3Download {
+
+  private val s3Client = S3Client.create
+
+  private val bucketName = sys.env.getOrElse("INPUT_BUCKET_NAME", "tdr-upload-files-dev")
+
+  def downloadFiles(files: Seq[File], consignmentId: Int): Unit = {
+    val s3FolderName = sys.env.getOrElse("INPUT_FOLDER_NAME", consignmentId.toString)
+
+    val tempFolderName = sys.env.get("OUTPUT_DIR")
+    val tempFolder = tempFolderName match {
+      case Some(folder) => Paths.get(folder)
+      case None => Files.createTempDirectory("tdr-export")
+    }
+
+    println(s"Saving files to ${tempFolder.toAbsolutePath}")
+
+    files.foreach(fileDetails => {
+      println(s"Downloading file '${fileDetails.id}' to its original path '${fileDetails.path}'")
+      download(fileDetails, s3FolderName, tempFolder)
+    })
+  }
+
+  private def download(fileDetails: File, s3FolderName: String, tempFolder: Path): Unit = {
+    val objectRequest = GetObjectRequest.builder
+      .bucket(bucketName)
+      .key(s"$s3FolderName/${fileDetails.id}")
+      .build
+    val outputPath: Path = Paths.get(s"$tempFolder/${fileDetails.path}")
+
+    createParentDirectories(outputPath)
+
+    s3Client.getObject(objectRequest, outputPath)
+  }
+
+  private def createParentDirectories(path: Path): Unit = {
+    new java.io.File(path.getParent.toString).mkdirs
+  }
+}


### PR DESCRIPTION
When downloading the files, first look up their original paths in the TDR API, and save the file from S3 to the original path rather than in the flat file structure and UUID naming convention that we use in S3.