### PR TITLE
Fix filepaths in client metadata file

### DIFF
--- a/download/src/main/scala/uk/gov/nationalarchives/tdr/export/bagit/ConsignmentBagger.scala
+++ b/download/src/main/scala/uk/gov/nationalarchives/tdr/export/bagit/ConsignmentBagger.scala
@@ -28,9 +28,10 @@ object ConsignmentBagger {
 
   private def generateClientSideMetadata(consignment: Consignment): Seq[Seq[Any]] = {
     val headerRow = Seq("file", "date_last_modified", "sha256", "filesize")
-    val clientMetadata = consignment.files.map(file =>
-      Seq(file.path, file.lastModifiedDate, file.fileStatus.clientSideChecksum, file.fileSize)
-    )
+    val clientMetadata = consignment.files.map(file => {
+      val pathInBag = s"data/${file.path}"
+      Seq(pathInBag, file.lastModifiedDate, file.fileStatus.clientSideChecksum, file.fileSize)
+    })
     headerRow +: clientMetadata
   }
 }


### PR DESCRIPTION
Save filepaths to the client metadata with a "data/" prefix so that their paths are relative to the root of the BagIt bag. This makes the metadata file consistent with the auto-generated files like the checksum manifests.